### PR TITLE
Fix `load_astrodb` function

### DIFF
--- a/astrodb_utils/utils.py
+++ b/astrodb_utils/utils.py
@@ -77,8 +77,8 @@ def load_astrodb(db_file, data_path="data/", recreatedb=True, reference_tables=N
             "Publications",
             "Telescopes",
             "Instruments",
-            "Modes",
             "Versions",
+            "PhotometryFilters",
         ]
     else:
         REFERENCE_TABLES = reference_tables

--- a/astrodb_utils/utils.py
+++ b/astrodb_utils/utils.py
@@ -68,20 +68,19 @@ class AstroDBError(Exception):
 #     sys.tracebacklimit = default_value  # revert changes
 
 
-def load_astrodb(db_file, data_path="data/", recreatedb=True, reference_tables=None):
+def load_astrodb(
+    db_file,
+    data_path="data/",
+    recreatedb=True,
+    reference_tables=[
+        "Publications",
+        "Telescopes",
+        "Instruments",
+        "Versions",
+        "PhotometryFilters",
+    ],
+):
     # Utility function to load the database
-
-    if reference_tables is None:
-        logger.warning("No reference tables provided. Using default tables.")
-        REFERENCE_TABLES = [
-            "Publications",
-            "Telescopes",
-            "Instruments",
-            "Versions",
-            "PhotometryFilters",
-        ]
-    else:
-        REFERENCE_TABLES = reference_tables
 
     db_file_path = Path(db_file)
     db_connection_string = "sqlite:///" + db_file
@@ -92,14 +91,14 @@ def load_astrodb(db_file, data_path="data/", recreatedb=True, reference_tables=N
     if not db_file_path.exists():
         try:  # Use fancy in-memory database, if supported by astrodbkit2
             db = Database(
-                "sqlite://", reference_tables=REFERENCE_TABLES
+                "sqlite://", reference_tables=reference_tables
             )  # creates and connects to a temporary in-memory database
             db.load_database(
                 data_path
             )  # loads the data from the data files into the database
             db.dump_sqlite(db_file)  # dump in-memory database to file
             db = Database(
-                db_connection_string, reference_tables=REFERENCE_TABLES
+                db_connection_string, reference_tables=reference_tables
             )  # replace database object with new file version
         except RuntimeError:
             # use in-file database
@@ -107,14 +106,14 @@ def load_astrodb(db_file, data_path="data/", recreatedb=True, reference_tables=N
                 db_connection_string
             )  # creates empty database based on the simple schema
             db = Database(
-                db_connection_string, reference_tables=REFERENCE_TABLES
+                db_connection_string, reference_tables=reference_tables
             )  # connects to the empty database
             db.load_database(
                 data_path
             )  # loads the data from the data files into the database
     else:
         db = Database(
-            db_connection_string, reference_tables=REFERENCE_TABLES
+            db_connection_string, reference_tables=reference_tables
         )  # if database already exists, connects to .db file
 
     return db

--- a/astrodb_utils/utils.py
+++ b/astrodb_utils/utils.py
@@ -18,7 +18,6 @@ from sqlalchemy import or_, and_
 import sqlalchemy.exc
 from astroquery.simbad import Simbad
 import socket
-# from scripts import REFERENCE_TABLES
 
 __all__ = [
     "AstroDBError",
@@ -68,20 +67,21 @@ class AstroDBError(Exception):
 #     yield
 #     sys.tracebacklimit = default_value  # revert changes
 
-# TODO:  Where should these live?
-REFERENCE_TABLES = [
-    "Publications",
-    "Telescopes",
-    "Instruments",
-    "Modes",
-    "PhotometryFilters",
-    "Versions",
-    "Parameters",
-]
 
-
-def load_astrodb(db_file, recreatedb=True, reference_tables=REFERENCE_TABLES):
+def load_astrodb(db_file, data_path="data/", recreatedb=True, reference_tables=None):
     # Utility function to load the database
+
+    if reference_tables is None:
+        logger.warning("No reference tables provided. Using default tables.")
+        REFERENCE_TABLES = [
+            "Publications",
+            "Telescopes",
+            "Instruments",
+            "Modes",
+            "Versions",
+        ]
+    else:
+        REFERENCE_TABLES = reference_tables
 
     db_file_path = Path(db_file)
     db_connection_string = "sqlite:///" + db_file
@@ -95,7 +95,7 @@ def load_astrodb(db_file, recreatedb=True, reference_tables=REFERENCE_TABLES):
                 "sqlite://", reference_tables=REFERENCE_TABLES
             )  # creates and connects to a temporary in-memory database
             db.load_database(
-                "data/"
+                data_path
             )  # loads the data from the data files into the database
             db.dump_sqlite(db_file)  # dump in-memory database to file
             db = Database(
@@ -110,7 +110,7 @@ def load_astrodb(db_file, recreatedb=True, reference_tables=REFERENCE_TABLES):
                 db_connection_string, reference_tables=REFERENCE_TABLES
             )  # connects to the empty database
             db.load_database(
-                "data/"
+                data_path
             )  # loads the data from the data files into the database
     else:
         db = Database(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,11 @@
 import pytest
-import os
 import sys
 import logging
-from astrodbkit2.astrodb import create_database, Database
 
 sys.path.append("./tests/astrodb-template-db/")
+from schema.schema_template import REFERENCE_TABLES
 from schema.schema_template import *  # import the schema of the template database
+from astrodb_utils import load_astrodb
 
 logger = logging.getLogger("AstroDB")
 
@@ -16,23 +16,10 @@ def db():
     DB_NAME = "tests/test-template-db.sqlite"
     DB_PATH = "tests/astrodb-template-db/data"
 
-    # Create a fresh temporary database and assert it exists
-    if os.path.exists(DB_NAME):
-        os.remove(DB_NAME)
-    connection_string = "sqlite:///" + DB_NAME
-    create_database(connection_string)
+    db = load_astrodb(
+        DB_NAME, data_path=DB_PATH, recreatedb=True, reference_tables=REFERENCE_TABLES
+    )
 
-    # Connect to the new database instance
-    db = Database(connection_string)
-    # Load data into an in-memory sqlite database first, for performance
-    db = Database("sqlite://")  # creates and connects to a temporary in-memory database
-    db.load_database(
-        DB_PATH, verbose=False
-    )  # loads the data from the data files into the database
-    db.dump_sqlite(DB_NAME)  # dump in-memory database to file
-    db = Database(
-        "sqlite:///" + DB_NAME
-    )  # replace database object with new file version
     logger.info("Loaded SIMPLE database using db function in conftest")
 
     return db

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,7 @@ import sys
 import logging
 
 sys.path.append("./tests/astrodb-template-db/")
-# from schema.schema_template import REFERENCE_TABLES
-# Waiting for PR#39 to be merged
+from schema.schema_template import REFERENCE_TABLES
 from schema.schema_template import *  # import the schema of the template database
 from astrodb_utils import load_astrodb
 
@@ -18,7 +17,7 @@ def db():
     DB_PATH = "tests/astrodb-template-db/data"
 
     db = load_astrodb(
-        DB_NAME, data_path=DB_PATH, recreatedb=True, reference_tables=None
+        DB_NAME, data_path=DB_PATH, recreatedb=True, reference_tables=REFERENCE_TABLES
     )
     # Use the default reference tables until astrodb-template-db PR #39 is merged
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,8 @@ import sys
 import logging
 
 sys.path.append("./tests/astrodb-template-db/")
-from schema.schema_template import REFERENCE_TABLES
+# from schema.schema_template import REFERENCE_TABLES
+# Waiting for PR#39 to be merged
 from schema.schema_template import *  # import the schema of the template database
 from astrodb_utils import load_astrodb
 
@@ -17,8 +18,9 @@ def db():
     DB_PATH = "tests/astrodb-template-db/data"
 
     db = load_astrodb(
-        DB_NAME, data_path=DB_PATH, recreatedb=True, reference_tables=REFERENCE_TABLES
+        DB_NAME, data_path=DB_PATH, recreatedb=True, reference_tables=None
     )
+    # Use the default reference tables until astrodb-template-db PR #39 is merged
 
     logger.info("Loaded SIMPLE database using db function in conftest")
 


### PR DESCRIPTION
- Provide a default group of REFERENCE_TABLES. Currently, these are the ones used by the template database.
- add `data_path=` keyword instead of hard coding to `data/`