### PR TITLE
Fix tests failing due to Photometry changes

### DIFF
--- a/astrodb_utils/photometry.py
+++ b/astrodb_utils/photometry.py
@@ -28,6 +28,7 @@ def ingest_photometry(
     *,
     source: str = None,
     band: str = None,
+    regime: str = None,
     magnitude: float = None,
     magnitude_error: float = None,
     reference: str = None,
@@ -44,6 +45,7 @@ def ingest_photometry(
     db: astrodbkit2.astrodb.Database
     source: str
     band: str
+    regime: str
     magnitude: float
     magnitude_error: float
     reference: str
@@ -151,6 +153,7 @@ def ingest_photometry(
         {
             "source": db_name,
             "band": band,
+            "regime": regime,
             "magnitude": str(
                 magnitude
             ),  # Convert to string to maintain significant digits
@@ -185,10 +188,10 @@ def ingest_photometry(
                 "Add it with add_publication function."
             )
             if raise_error:
-                logger.error(msg)
-                raise AstroDBError(msg)
+                logger.error(msg+str(e))
+                raise AstroDBError(msg+str(e))
             else:
-                logger.warning(msg)
+                logger.warning(msg+str(e))
 
     return flags
 

--- a/astrodb_utils/photometry.py
+++ b/astrodb_utils/photometry.py
@@ -191,7 +191,7 @@ def ingest_photometry(
                 logger.error(msg+str(e))
                 raise AstroDBError(msg+str(e))
             else:
-                logger.warning(f"{msg}/n{str(e)})
+                logger.warning(f"{msg}/n{str(e)}")
 
     return flags
 

--- a/astrodb_utils/photometry.py
+++ b/astrodb_utils/photometry.py
@@ -191,7 +191,7 @@ def ingest_photometry(
                 logger.error(msg+str(e))
                 raise AstroDBError(msg+str(e))
             else:
-                logger.warning(msg+str(e))
+                logger.warning(f"{msg}/n{str(e)})
 
     return flags
 

--- a/astrodb_utils/tests/test_photometry.py
+++ b/astrodb_utils/tests/test_photometry.py
@@ -1,11 +1,12 @@
-import pytest
 import astropy.units as u
+import pytest
+
 from astrodb_utils import AstroDBError
 from astrodb_utils.photometry import (
+    assign_ucd,
+    fetch_svo,
     ingest_photometry,
     ingest_photometry_filter,
-    fetch_svo,
-    assign_ucd,
 )
 
 
@@ -14,6 +15,7 @@ def test_ingest_photometry(db):
         db,
         source="Dark energy source 1",
         band="Generic/Johnson.V",
+        regime="optical",
         magnitude=10,
         reference="Rubin80",
     )
@@ -21,6 +23,7 @@ def test_ingest_photometry(db):
         db,
         source="Dark energy source 2",
         band="Generic/Cousins.R",
+        regime="optical",
         magnitude=10,
         reference="Riess98",
         telescope="Generic",


### PR DESCRIPTION
the tests were failing due to adding `regime` to the template.  This PR updates the `ingest_photometry` function and the associated tests.