### PR TITLE
Adding `fuzzy=false` to `find_source_in_db` and use in `ingest_source`

### DIFF
--- a/astrodb_utils/publications.py
+++ b/astrodb_utils/publications.py
@@ -298,6 +298,7 @@ def ingest_publication(
         arxiv_id = None
 
     name_add, bibcode_add, doi_add = "", "", ""
+    using = f"ref: {name_add}, bibcode: {bibcode_add}, doi: {doi_add}"
     # Search ADS uing a provided arxiv id
     if arxiv_id and use_ads:
         arxiv_matches = ads.SearchQuery(
@@ -329,8 +330,6 @@ def ingest_publication(
         bibcode_add = arxiv_id
         doi_add = doi
         using = f"ref: {name_add}, bibcode: {bibcode_add}, doi: {doi_add}"
-    else:
-        using = "not sure yet, no arxiv id provided"
 
     # Search ADS using a provided DOI
     if doi and use_ads:
@@ -344,7 +343,6 @@ def ingest_publication(
 
         if len(doi_matches_list) == 1:
             logger.debug(f"Publication found in ADS using DOI: {doi}")
-            using = doi
             article = doi_matches_list[0]
             logger.debug(
                 f"{article.first_author}, {article.year},"
@@ -358,6 +356,7 @@ def ingest_publication(
             description = article.title[0]
             bibcode_add = article.bibcode
             doi_add = article.doi[0]
+            using = f"ref: {name_add}, bibcode: {bibcode_add}, doi: {doi_add}"
     elif doi:
         name_add = reference
         bibcode_add = bibcode
@@ -380,7 +379,6 @@ def ingest_publication(
 
         elif len(bibcode_matches_list) == 1:
             logger.debug(f"Publication found in ADS using bibcode: {bibcode}")
-            using = f"bibcode: {bibcode}"
             article = bibcode_matches_list[0]
             logger.debug(
                 f"{article.first_author}, {article.year}, "
@@ -397,6 +395,7 @@ def ingest_publication(
                 doi_add = None
             else:
                 doi_add = article.doi[0]
+            using = f"ref: {name_add}, bibcode: {bibcode_add}, doi: {doi_add}"
     elif bibcode:
         name_add = reference
         bibcode_add = bibcode

--- a/astrodb_utils/sources.py
+++ b/astrodb_utils/sources.py
@@ -228,7 +228,7 @@ def ingest_names(
 def ingest_source(
     db,
     source,
-    reference: str = None,
+    reference: str,
     *,
     ra: float = None,
     dec: float = None,

--- a/astrodb_utils/sources.py
+++ b/astrodb_utils/sources.py
@@ -224,8 +224,8 @@ def ingest_names(
 def ingest_source(
     db,
     source,
-    *,
     reference: str = None,
+    *,
     ra: float = None,
     dec: float = None,
     epoch: str = None,
@@ -282,6 +282,19 @@ def ingest_source(
 
     logger.debug(f"Trying to ingest source: {source}")
 
+    # Make sure reference is provided and in References table
+    ref_check = find_publication(db, reference=reference)
+    logger.debug(f"ref_check: {ref_check}")
+    if ref_check[0] is False:
+        msg = (
+            f"Skipping: {source}."
+            f"Discovery reference {reference} is either missing or "
+            " is not in Publications table. \n"
+            f"(Add it with ingest_publication function.)"
+        )
+        exit_function(msg, raise_error)
+        return
+
     # Find out if source is already in database or not
     if search_db:
         logger.debug(f"Checking database for: {source} at ra: {ra}, dec: {dec}")
@@ -314,19 +327,6 @@ def ingest_source(
             msg2 = f"   More than one match for {source}\n {name_matches}\n"
 
         exit_function(msg1 + msg2, raise_error)
-        return
-
-    # Make sure reference is provided and in References table
-    ref_check = find_publication(db, reference=reference)
-    logger.debug(f"ref_check: {ref_check}")
-    if ref_check[0] is False:
-        msg = (
-            f"Skipping: {source}."
-            f"Discovery reference {reference} is either missing or "
-            " is not in Publications table. \n"
-            f"(Add it with ingest_publication function.)"
-        )
-        exit_function(msg, raise_error)
         return
 
     # Try to get coordinates from SIMBAD if they were not provided

--- a/astrodb_utils/sources.py
+++ b/astrodb_utils/sources.py
@@ -28,9 +28,11 @@ def find_source_in_db(
     ra_col_name="ra_deg",
     dec_col_name="dec_deg",
     use_simbad=True,
+    fuzzy=False
 ):
     """
     Find a source in the database given a source name and optional coordinates.
+    Uses astrodbkit .search_object and .query_region methods to search the Sources and Names table.
 
     Parameters
     ----------
@@ -50,6 +52,8 @@ def find_source_in_db(
     use_simbad: bool
         Use Simbad to resolve the source name if it is not found in the database. Default is True.
         Set to False if no internet connection.
+    fuzzy: bool
+        Use fuzzy search to find source name in database. Default is False.
 
     Returns
     -------
@@ -74,7 +78,7 @@ def find_source_in_db(
 
     # NO MATCHES
     # If no matches, try fuzzy search
-    if len(db_name_matches) == 0:
+    if len(db_name_matches) == 0 and fuzzy:
         logger.debug(f"{source}: No name matches, trying fuzzy search")
         db_name_matches = db.search_object(
             source,

--- a/astrodb_utils/tests/conftest.py
+++ b/astrodb_utils/tests/conftest.py
@@ -4,6 +4,8 @@ import sys
 import pytest
 
 from astrodb_utils import load_astrodb, logger
+from astrodb_utils.publications import ingest_publication
+from astrodb_utils.sources import ingest_source
 
 logger.setLevel("DEBUG")
 
@@ -24,6 +26,20 @@ def db():
     # Confirm file was created
     assert os.path.exists(DB_NAME)
 
-    logger.info("Loaded SIMPLE database using load_astrodb function in conftest.py")
+    logger.info("Loaded AstroDB Template database using load_astrodb function in conftest.py")
+
+    ingest_publication(db, doi="10.1086/161442") # Prob83
+
+    ingest_publication(
+        db,
+        reference="Refr20",
+        bibcode="2020MNRAS.496.1922B",
+        doi="10.1093/mnras/staa1522",
+        ignore_ads=True,
+    )
+
+    ingest_source(db, "LHS 2924", reference="Prob83")
 
     return db
+
+

--- a/astrodb_utils/tests/conftest.py
+++ b/astrodb_utils/tests/conftest.py
@@ -28,7 +28,7 @@ def db():
 
     logger.info("Loaded AstroDB Template database using load_astrodb function in conftest.py")
 
-    ingest_publication(db, doi="10.1086/161442") # Prob83
+   
 
     ingest_publication(
         db,
@@ -37,6 +37,8 @@ def db():
         doi="10.1093/mnras/staa1522",
         ignore_ads=True,
     )
+
+    ingest_publication(db, doi="10.1086/161442", reference="Prob83")
 
     ingest_source(db, "LHS 2924", reference="Prob83")
 

--- a/astrodb_utils/tests/test_publications.py
+++ b/astrodb_utils/tests/test_publications.py
@@ -4,23 +4,6 @@ from astrodb_utils import AstroDBError
 from astrodb_utils.publications import find_publication, ingest_publication
 
 
-def test_ingest_publications(db):
-    # add a made up publication and make sure it's there
-    ingest_publication(
-        db,
-        reference="Refr20",
-        bibcode="2020MNRAS.496.1922B",
-        doi="10.1093/mnras/staa1522",
-        ignore_ads=True,
-    )
-    assert (
-        db.query(db.Publications)
-        .filter(db.Publications.c.reference == "Refr20")
-        .count()
-        == 1
-    )
-
-
 def test_find_publication(db):
     assert not find_publication(db)[0]  # False
     assert find_publication(db, reference="Refr20")[0]  # True

--- a/astrodb_utils/tests/test_sources.py
+++ b/astrodb_utils/tests/test_sources.py
@@ -11,8 +11,6 @@ from astrodb_utils.sources import (
     ingest_source,
 )
 
-# TODO: Ingest publication just for these tests so they can be run independent of test_publications.py
-
 
 @pytest.mark.parametrize(
     "source_data",
@@ -88,6 +86,16 @@ def test_find_source_in_db(db):
         ra=100,
         dec=17,
     )
+    assert len(search_result) == 0
+
+    search_result = find_source_in_db(db,"LHS 2924")
+    # print(f"LHS 2924: {search_result}")
+    assert search_result[0] == "LHS 2924"
+
+    search_result = find_source_in_db(db,"LHS 292")
+    assert search_result[0] == "LHS 2924"  # This is wrong and a result of fuzzy matching
+
+    search_result = find_source_in_db(db,"LHS 292", fuzzy=False)
     assert len(search_result) == 0
 
 

--- a/astrodb_utils/tests/test_sources.py
+++ b/astrodb_utils/tests/test_sources.py
@@ -89,14 +89,13 @@ def test_find_source_in_db(db):
     assert len(search_result) == 0
 
     search_result = find_source_in_db(db,"LHS 2924")
-    # print(f"LHS 2924: {search_result}")
     assert search_result[0] == "LHS 2924"
-
-    search_result = find_source_in_db(db,"LHS 292")
-    assert search_result[0] == "LHS 2924"  # This is wrong and a result of fuzzy matching
 
     search_result = find_source_in_db(db,"LHS 292", fuzzy=False)
     assert len(search_result) == 0
+
+    search_result = find_source_in_db(db,"LHS 292", fuzzy=True)
+    assert search_result[0] == "LHS 2924"  # This is wrong and a result of fuzzy matching
 
 
 def test_find_source_in_db_errors(db):


### PR DESCRIPTION
- `Find_source_in_db` is finding too many things and needs a `fuzzy=false` option. #115 
- `ingest_source` now works better since default is fuzzy=false in find_source_in_db 
- also fixes issue in `ingest_publication` #106 
- got a little carried away and started decreasing complexity of ingest_publication.