### PR TITLE
Improvements to `find_source_in_db` function

### DIFF
--- a/astrodb_utils/sources.py
+++ b/astrodb_utils/sources.py
@@ -133,7 +133,7 @@ def find_source_in_db(
             ra
             and dec
             and u.isclose(ra*u.degree, db_name_matches[ra_col_name][0]*u.degree,atol=search_radius)
-            and np.isclose(dec*u.degree, db_name_matches[dec_col_name][0]*u.degree, atol=search_radius)
+            and u.isclose(dec*u.degree, db_name_matches[dec_col_name][0]*u.degree, atol=search_radius)
         )
         if ra and dec and not coord_check:
             msg = (

--- a/astrodb_utils/sources.py
+++ b/astrodb_utils/sources.py
@@ -21,15 +21,15 @@ logger = logging.getLogger("astrodb_utils")
 
 def find_source_in_db(
     db,
-    source,
+    source: str,
     *,
-    ra=None,
-    dec=None,
-    search_radius=60.0*u.arcsec,
-    ra_col_name="ra_deg",
-    dec_col_name="dec_deg",
-    use_simbad=True,
-    fuzzy=False,
+    ra: float = None,
+    dec: float = None,
+    search_radius: u.Quantity = 60.0 * u.arcsec,
+    ra_col_name: str = "ra_deg",
+    dec_col_name: str = "dec_deg",
+    use_simbad: bool = True,
+    fuzzy: bool = False,
 ):
     """
     Find a source in the database given a source name and optional coordinates.
@@ -44,7 +44,7 @@ def find_source_in_db(
         Right ascensions of sources. Decimal degrees.
     dec: float
         Declinations of sources. Decimal degrees.
-    search_radius: Quantity
+    search_radius: u.Quantity
         Search radius. Default is 60 arcseconds.
     ra_col_name: str
         Name of the column in the database table that contains the right ascension

--- a/astrodb_utils/tests/test_sources.py
+++ b/astrodb_utils/tests/test_sources.py
@@ -88,14 +88,39 @@ def test_find_source_in_db(db):
     )
     assert len(search_result) == 0
 
-    search_result = find_source_in_db(db,"LHS 2924")
+    search_result = find_source_in_db(db, "LHS 2924")
     assert search_result[0] == "LHS 2924"
 
-    search_result = find_source_in_db(db,"LHS 292", fuzzy=False)
+    search_result = find_source_in_db(db, "LHS 292", fuzzy=False)
     assert len(search_result) == 0
 
-    search_result = find_source_in_db(db,"LHS 292", fuzzy=True)
-    assert search_result[0] == "LHS 2924"  # This is wrong and a result of fuzzy matching
+    search_result = find_source_in_db(db, "LHS 292", fuzzy=True)
+    assert (
+        search_result[0] == "LHS 2924"
+    )  # This is wrong and a result of fuzzy matching
+
+
+def test_find_source_in_db_with_coords(db):
+    ingest_source(
+        db,
+        "2MASS J04470652-1946392",
+        reference="Cutr03",
+    )
+
+    source = "2MASS J04470652-1946392"
+    ra_wrong = 68.8966272
+    dec_wrong = 21.2552596
+
+    search_result = find_source_in_db(
+        db,
+        source,
+        ra=ra_wrong,
+        dec=dec_wrong,
+        ra_col_name="ra",
+        dec_col_name="dec",
+    )
+    assert len(search_result) == 0
+    print(search_result)
 
 
 def test_find_source_in_db_errors(db):

--- a/astrodb_utils/tests/test_sources.py
+++ b/astrodb_utils/tests/test_sources.py
@@ -116,11 +116,8 @@ def test_find_source_in_db_with_coords(db):
         source,
         ra=ra_wrong,
         dec=dec_wrong,
-        ra_col_name="ra",
-        dec_col_name="dec",
     )
     assert len(search_result) == 0
-    print(search_result)
 
 
 def test_find_source_in_db_errors(db):

--- a/astrodb_utils/tests/test_sources.py
+++ b/astrodb_utils/tests/test_sources.py
@@ -1,5 +1,6 @@
 import math
 
+import astropy.units as u
 import pytest
 
 from astrodb_utils import (
@@ -118,6 +119,23 @@ def test_find_source_in_db_with_coords(db):
         dec=dec_wrong,
     )
     assert len(search_result) == 0
+
+    search_result = find_source_in_db(
+        db,
+        source,
+        ra=71.8, 
+        dec=-19.8 
+    )
+    assert len(search_result) == 0  # coords not within 60 arcsec
+
+    search_result = find_source_in_db(
+        db,
+        source,
+        ra=71.8, 
+        dec=-19.8,
+        search_radius=83*u.arcsec,
+    )
+    assert len(search_result) == 1  # coords are within 83 arcsec
 
 
 def test_find_source_in_db_errors(db):


### PR DESCRIPTION
If coords are given to find_source_in_db and the coords don't match with those in the database, the search result should not be passed.  This can happen when the input data is corrupted.

Closes #125 