### PR TITLE
Better error catching in find_source

### DIFF
--- a/astrodb_utils/sources.py
+++ b/astrodb_utils/sources.py
@@ -127,9 +127,19 @@ def find_source_in_db(
                 f"using ra_col_name: {ra_col_name}, dec_col_name: {dec_col_name}"
             )
             logger.debug(msg2)
-            db_name_matches = db.query_region(
+            try:
+                db_name_matches = db.query_region(
                 simbad_skycoord, radius=search_radius, ra_col=ra_col_name, dec_col=dec_col_name
             )
+            except KeyError as e:
+                msg = (
+                    f"Error querying database with coordinates from SIMBAD: {e}\n"
+                    f"Using skycoord: {simbad_skycoord} and ra_col_name: {ra_col_name}, dec_col_name: {dec_col_name}.\n"
+                    "Try setting `ra_col_name` and `dec_col_name` arguments to the "
+                    "column names used in the Sources table.\n"
+                )
+                logger.error(msg)
+                raise AstroDBError(msg)
 
     if len(db_name_matches) == 1:
         db_names = db_name_matches["source"].tolist()

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -160,6 +160,15 @@ def test_find_source_in_db_errors(db):
         )
     assert "bad_column_name" in str(error_message)
 
+    with pytest.raises(AstroDBError) as error_message:
+        find_source_in_db(
+            db,
+            "sirius",
+            ra_col_name="bad_column_name",
+            dec_col_name="bad_column_name",
+        )
+    assert "column names used in the Sources table" in str(error_message)
+
 
 @pytest.mark.filterwarnings(
     "ignore::UserWarning"


### PR DESCRIPTION
Improved error catching in `find_source` when sources are given and the ra/dec column names are needed to search for coordinate matches.