### PR TITLE
Clone astrodb-template for the docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,6 +19,7 @@ import os
 import sys
 from importlib.metadata import version
 
+from git import Repo
 from sphinx_pyproject import SphinxConfig
 
 astrodb_utils_version = version("astrodb_utils")
@@ -33,6 +34,14 @@ sys.path.insert(0, os.path.abspath("../.."))
 sys.path.insert(0, os.path.abspath(".."))
 sys.path.insert(0, os.path.abspath("../schema"))
 
+# Get markdown files for the template schema from astrodb-template-db/ repository 
+
+template_schema_path = "pages/template_schema/astrodb-template-db"
+if os.path.exists(template_schema_path):
+    template_repo = Repo(template_schema_path)
+    template_repo.remotes.origin.pull()
+else:
+    Repo.clone_from("https://github.com/astrodbtoolkit/astrodb-template-db.git", template_schema_path, branch="main")
 
 # -- General configuration ------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,7 +34,7 @@ sys.path.insert(0, os.path.abspath("../.."))
 sys.path.insert(0, os.path.abspath(".."))
 sys.path.insert(0, os.path.abspath("../schema"))
 
-# Get markdown files for the template schema from astrodb-template-db/ repository 
+# Get markdown files for the template schema from astrodb-template-db/ repository
 
 template_schema_path = "pages/template_schema/astrodb-template-db"
 if os.path.exists(template_schema_path):

--- a/docs/doc_requirements.txt
+++ b/docs/doc_requirements.txt
@@ -6,3 +6,4 @@ pydata-sphinx-theme
 mock
 sphinx-pyproject
 sphinx_mdinclude 
+gitpython

--- a/docs/pages/dev_docs/documentation.rst
+++ b/docs/pages/dev_docs/documentation.rst
@@ -15,6 +15,6 @@ To build the docs, use `sphinx-autobuild <https://pypi.org/project/sphinx-autobu
 .. code-block:: bash
 
     pip install -e ".[docs]"
-    sphinx-autobuild docs docs/_build/html
+    sphinx-autobuild docs docs/_build/html --ignore=docs/pages/template_schema/astrodb-template-db/.git/
 
 The docs will then be available locally at <http://127.0.0.1:8000>.

--- a/docs/pages/template_schema/data_tables/associations.rst
+++ b/docs/pages/template_schema/data_tables/associations.rst
@@ -8,6 +8,6 @@ Association
 Table Documentation
 ===================
 
-.. mdinclude:: ../../../../astrodb-template-db/docs/schema/Associations.md
-
+.. mdinclude:: ../astrodb-template-db/docs/schema/Associations.md
+.. mdinclude:: ../astrodb-template-db/docs/schema/AssociationList.md
 

--- a/docs/pages/template_schema/data_tables/associations.rst
+++ b/docs/pages/template_schema/data_tables/associations.rst
@@ -9,5 +9,4 @@ Table Documentation
 ===================
 
 .. mdinclude:: ../astrodb-template-db/docs/schema/Associations.md
-.. mdinclude:: ../astrodb-template-db/docs/schema/AssociationList.md
 

--- a/docs/pages/template_schema/data_tables/companion_relationships.rst
+++ b/docs/pages/template_schema/data_tables/companion_relationships.rst
@@ -23,4 +23,4 @@ Table documentation
 The below table is built directly from the schema and is
 included here from the `astrodb-template-db` documentation: `source`_.
 
-.. mdinclude:: ../../../../astrodb-template-db/docs/schema/CompanionRelationships.md
+.. mdinclude:: ../astrodb-template-db/docs/schema/CompanionRelationships.md

--- a/docs/pages/template_schema/data_tables/companionparameters.rst
+++ b/docs/pages/template_schema/data_tables/companionparameters.rst
@@ -17,4 +17,4 @@ Table Documentation
 The below table is built directly from the schema and is
 included here from the `astrodb-template-db` documentation: `source`_.
 
-.. mdinclude:: ../../../../astrodb-template-db/docs/schema/CompanionParameters.md
+.. mdinclude:: ../astrodb-template-db/docs/schema/CompanionParameters.md

--- a/docs/pages/template_schema/data_tables/modeledparameters.rst
+++ b/docs/pages/template_schema/data_tables/modeledparameters.rst
@@ -13,4 +13,4 @@ Table Documentation
 The below table is built directly from the schema and is
 included here from the `astrodb-template-db` documentation: `source`_.
 
-.. mdinclude:: ../../../../astrodb-template-db/docs/schema/ModeledParameters.md
+.. mdinclude:: ../astrodb-template-db/docs/schema/ModeledParameters.md

--- a/docs/pages/template_schema/data_tables/parallaxes.rst
+++ b/docs/pages/template_schema/data_tables/parallaxes.rst
@@ -8,4 +8,4 @@ Table Documentation
 The below table is built directly from the schema and is
 included here from the `astrodb-template-db` documentation: `source`_.
 
-.. mdinclude:: ../../../../astrodb-template-db/docs/schema/Parallaxes.md
+.. mdinclude:: ../astrodb-template-db/docs/schema/Parallaxes.md

--- a/docs/pages/template_schema/data_tables/photometry.rst
+++ b/docs/pages/template_schema/data_tables/photometry.rst
@@ -29,4 +29,4 @@ Table documentation
 The below table is built directly from the schema and is
 included here from the `astrodb-template-db` documentation: `source`_.
 
-.. mdinclude:: ../../../../astrodb-template-db/docs/schema/Photometry.md
+.. mdinclude:: ../astrodb-template-db/docs/schema/Photometry.md

--- a/docs/pages/template_schema/data_tables/propermotions.rst
+++ b/docs/pages/template_schema/data_tables/propermotions.rst
@@ -8,4 +8,4 @@ Table Documentation
 The below table is built directly from the schema and is
 included here from the `astrodb-template-db` documentation: `source`_.
 
-.. mdinclude:: ../../../../astrodb-template-db/docs/schema/ProperMotions.md
+.. mdinclude:: ../astrodb-template-db/docs/schema/ProperMotions.md

--- a/docs/pages/template_schema/data_tables/radialvelocities.rst
+++ b/docs/pages/template_schema/data_tables/radialvelocities.rst
@@ -8,4 +8,4 @@ Table Documentation
 The below table is built directly from the schema and is
 included here from the `astrodb-template-db` documentation: `source`_.
 
-.. mdinclude:: ../../../../astrodb-template-db/docs/schema/RadialVelocities.md
+.. mdinclude:: ../astrodb-template-db/docs/schema/RadialVelocities.md

--- a/docs/pages/template_schema/data_tables/rotationalparameters.rst
+++ b/docs/pages/template_schema/data_tables/rotationalparameters.rst
@@ -9,4 +9,4 @@ Table Documentation
 The below table is built directly from the schema and is
 included here from the `astrodb-template-db` documentation: `source`_.
 
-.. mdinclude:: ../../../../astrodb-template-db/docs/schema/RotationalParameters.md
+.. mdinclude:: ../astrodb-template-db/docs/schema/RotationalParameters.md

--- a/docs/pages/template_schema/data_tables/sourcetypes.rst
+++ b/docs/pages/template_schema/data_tables/sourcetypes.rst
@@ -14,4 +14,4 @@ Table documentation
 The below table is built directly from the schema and is
 included here from the `astrodb-template-db` documentation: `source`_.
 
-.. mdinclude:: ../../../../astrodb-template-db/docs/schema/SourceTypes.md
+.. mdinclude:: ../astrodb-template-db/docs/schema/SourceTypes.md

--- a/docs/pages/template_schema/lookup_tables/associationlist.rst
+++ b/docs/pages/template_schema/lookup_tables/associationlist.rst
@@ -13,5 +13,5 @@ Table Documentation
 The below table is built directly from the schema and is
 included here from the `astrodb-template-db` documentation: `source`_.
 
-.. mdinclude:: ../../../../astrodb-template-db/docs/schema/AssociationList.md
+.. mdinclude:: ../astrodb-template-db/docs/schema/AssociationList.md
 

--- a/docs/pages/template_schema/lookup_tables/companionlist.rst
+++ b/docs/pages/template_schema/lookup_tables/companionlist.rst
@@ -13,4 +13,4 @@ Table Documentation
 The below table is built directly from the schema and is
 included here from the `astrodb-template-db` documentation: `source`_.
 
-.. mdinclude:: ../../../../astrodb-template-db/docs/schema/CompanionList.md
+.. mdinclude:: ../astrodb-template-db/docs/schema/CompanionList.md

--- a/docs/pages/template_schema/lookup_tables/instruments.rst
+++ b/docs/pages/template_schema/lookup_tables/instruments.rst
@@ -17,4 +17,4 @@ Table Documentation
 The below table is built directly from the schema and is
 included here from the `astrodb-template-db` documentation: `source`_.
 
-.. mdinclude:: ../../../../astrodb-template-db/docs/schema/Instruments.md
+.. mdinclude:: ../astrodb-template-db/docs/schema/Instruments.md

--- a/docs/pages/template_schema/lookup_tables/parameterlist.rst
+++ b/docs/pages/template_schema/lookup_tables/parameterlist.rst
@@ -16,4 +16,4 @@ Table Documentation
 The below table is built directly from the schema and is
 included here from the `astrodb-template-db` documentation: `source`_.
 
-.. mdinclude:: ../../../../astrodb-template-db/docs/schema/ParameterList.md
+.. mdinclude:: ../astrodb-template-db/docs/schema/ParameterList.md

--- a/docs/pages/template_schema/lookup_tables/photometryfilters.rst
+++ b/docs/pages/template_schema/lookup_tables/photometryfilters.rst
@@ -42,4 +42,4 @@ The below table is built directly from the schema and is
 included here from the `astrodb-template-db` documentation: `source`_.
 
 
-.. mdinclude:: ../../../../astrodb-template-db/docs/schema/PhotometryFilters.md
+.. mdinclude:: ../astrodb-template-db/docs/schema/PhotometryFilters.md

--- a/docs/pages/template_schema/lookup_tables/publications.rst
+++ b/docs/pages/template_schema/lookup_tables/publications.rst
@@ -27,6 +27,6 @@ Notes
 Table documentation
 -------------------
 
-.. mdinclude:: ../../../../astrodb-template-db/docs/schema/Publications.md
+.. mdinclude:: ../astrodb-template-db/docs/schema/Publications.md
 
 

--- a/docs/pages/template_schema/lookup_tables/regimelist.rst
+++ b/docs/pages/template_schema/lookup_tables/regimelist.rst
@@ -8,4 +8,4 @@ Table Documentation
 The below table is built directly from the schema and is
 included here from the `astrodb-template-db` documentation: `source`_.
 
-.. mdinclude:: ../../../../astrodb-template-db/docs/schema/RegimeList.md
+.. mdinclude:: ../astrodb-template-db/docs/schema/RegimeList.md

--- a/docs/pages/template_schema/lookup_tables/sourcetypelist.rst
+++ b/docs/pages/template_schema/lookup_tables/sourcetypelist.rst
@@ -12,4 +12,4 @@ Table Documentation
 The below table is built directly from the schema and is
 included here from the `astrodb-template-db` documentation: `source`_.
 
-.. mdinclude:: ../../../../astrodb-template-db/docs/schema/SourceTypeList.md
+.. mdinclude:: ../astrodb-template-db/docs/schema/SourceTypeList.md

--- a/docs/pages/template_schema/lookup_tables/telescopes.rst
+++ b/docs/pages/template_schema/lookup_tables/telescopes.rst
@@ -8,4 +8,4 @@ Table Documentation
 The below table is built directly from the schema and is
 included here from the `astrodb-template-db` documentation: `source`_.
 
-.. mdinclude:: ../../../../astrodb-template-db/docs/schema/Telescopes.md
+.. mdinclude:: ../astrodb-template-db/docs/schema/Telescopes.md

--- a/docs/pages/template_schema/main_tables/names.rst
+++ b/docs/pages/template_schema/main_tables/names.rst
@@ -13,5 +13,5 @@ Table Documentation
 The below table is built directly from the schema and is
 included here from the `astrodb-template-db` documentation: `source`_.
 
-.. mdinclude:: ../../../../astrodb-template-db/docs/schema/Names.md
+.. mdinclude:: ../astrodb-template-db/docs/schema/Names.md
 

--- a/docs/pages/template_schema/main_tables/sources.rst
+++ b/docs/pages/template_schema/main_tables/sources.rst
@@ -26,5 +26,5 @@ Notes
 Table documentation
 -------------------
 
-.. mdinclude:: ../../../../astrodb-template-db/docs/schema/Sources.md
+.. mdinclude:: ../astrodb-template-db/docs/schema/Sources.md
 

--- a/docs/pages/template_schema/main_tables/versions.rst
+++ b/docs/pages/template_schema/main_tables/versions.rst
@@ -9,4 +9,4 @@ Table Documentation
 The below table is built directly from the schema and is
 included here from the `astrodb-template-db` documentation: `source`_.
 
-.. mdinclude:: ../../../../astrodb-template-db/docs/schema/Versions.md
+.. mdinclude:: ../astrodb-template-db/docs/schema/Versions.md


### PR DESCRIPTION
Since we no longer have the astrodb-template as a submodule, the docs were not finding the felis-generated markdown files for the tables.  I have modified the sphinx conf.py to clone the template repo so that we have access to those files for inclusion in the docs.