### PR TITLE
Add astrodb-ingest-publication to AI skills documentation

### DIFF
--- a/docs/pages/db_access/ingesting/ingesting_publications.rst
+++ b/docs/pages/db_access/ingesting/ingesting_publications.rst
@@ -56,11 +56,23 @@ Below is an example script for ingesting the discovery publication for Rojas et 
 
 
 
+Using the AI Skill
+------------------
+
+The `astrodb-ingest-publication <https://github.com/astrodbtoolkit/astrodb_bot/blob/main/skills/astrodb-ingest-publication/SKILL.md>`_
+skill automates the steps above. It generates and runs a script that adds publications to the
+``Publications`` table using ``ingest_publication``, and can handle a single paper, a batch
+from a data file's reference column, or backfilling existing rows with missing metadata.
+
+See :doc:`/pages/db_management/agent_skills` for installation instructions and an overview of all
+available skills.
+
+
 .. seealso::
 
   :doc:`/pages/getting_started/template_schema/lookup_tables/publications`
       Documentation on the Publications table
 
   :py:mod:`find publication <astrodb_utils.publications.find_publication>` function
-        
+
   :py:mod:`ingest_publication <astrodb_utils.publications.ingest_publication>` function

--- a/docs/pages/db_management/agent_skills.rst
+++ b/docs/pages/db_management/agent_skills.rst
@@ -68,6 +68,13 @@ repository.
    `astrodb-template-db <https://github.com/astrodbtoolkit/astrodb-template-db>`_ file
    layout, and generates a matching test suite.
 
+#. `astrodb-ingest-publication <https://github.com/astrodbtoolkit/astrodb_bot/blob/main/skills/astrodb-ingest-publication/SKILL.md>`_
+   — Generates and runs a script that adds publications (references/citations) to the
+   ``Publications`` lookup table using ``astrodb_utils.publications.ingest_publication``.
+   Handles a single paper, a batch from a data file's reference column, or backfilling
+   existing rows with missing metadata. Every reference used elsewhere in the database
+   must exist here first. See also :doc:`../db_access/ingesting/ingesting_publications`.
+
 #. `astrodb-ingest-source <https://github.com/astrodbtoolkit/astrodb_bot/blob/main/skills/astrodb-ingest-source/SKILL.md>`_
    — Generates and runs a script that ingests sources from the data table into the new
    database using ``astrodb_utils.sources.ingest_source``. See also

--- a/docs/pages/getting_started/template_schema/lookup_tables/publications.rst
+++ b/docs/pages/getting_started/template_schema/lookup_tables/publications.rst
@@ -19,9 +19,6 @@ Notes
         `astrodb-ingest-publication <https://github.com/astrodbtoolkit/astrodb_bot/blob/main/skills/astrodb-ingest-publication/SKILL.md>`_
         AI skill that automates this process
 
-    :doc:`/pages/db_management/agent_skills`
-        Overview of all available AI skills
-
     :py:mod:`ingest_publication <astrodb_utils.publications.ingest_publication>`
         Function to ingest publication data
 

--- a/docs/pages/getting_started/template_schema/lookup_tables/publications.rst
+++ b/docs/pages/getting_started/template_schema/lookup_tables/publications.rst
@@ -15,7 +15,12 @@ Notes
 .. seealso::
 
     :ref:`ingesting_publications`
-        Documenation on ingesting publications 
+        Documentation on ingesting publications, including the
+        `astrodb-ingest-publication <https://github.com/astrodbtoolkit/astrodb_bot/blob/main/skills/astrodb-ingest-publication/SKILL.md>`_
+        AI skill that automates this process
+
+    :doc:`/pages/db_management/agent_skills`
+        Overview of all available AI skills
 
     :py:mod:`ingest_publication <astrodb_utils.publications.ingest_publication>`
         Function to ingest publication data


### PR DESCRIPTION
Documents the ingest-publication skill in agent_skills.rst, placed before ingest-source to reflect the required ingestion order (publications must exist before sources can reference them).